### PR TITLE
remove voter_id_requirements field from ballot model

### DIFF
--- a/response_builder/v1/models/base.py
+++ b/response_builder/v1/models/base.py
@@ -148,7 +148,6 @@ class Ballot(BaseModel):
     seats_contested: int = Field(default=1)
     hustings: Optional[List[Husting]] = Field(default=None)
     requires_voter_id: Optional[str] = Field(default=False)
-    voter_id_requirements: Optional[str]
     postal_voting_requirements: Optional[str]
 
     @validator("ballot_paper_id")


### PR DESCRIPTION
This is something I hit while I was working on https://github.com/DemocracyClub/aggregator-api/pull/608/
My tests are failing because we're expecting a field called `voter_id_requirements` but none of our APIs have this field. Only `requires_voter_id`. It would be quite nice if it were named `voter_id_requirements` because then it would be consistent with `postal_voting_requirements`, but `requires_voter_id` is what we expose.