### PR TITLE
widen range for uk-election-ids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
             "response_builder/v1/**/*",
         ]
     },
-    install_requires=["uk-election-ids==0.8.0", "pydantic[email]>=1.10,<2"],
+    install_requires=["uk-election-ids>=0.8.0", "pydantic[email]>=1.10,<2"],
 )


### PR DESCRIPTION
Probably doesn't immediately need to go in a release, but while I was working out the impacts of https://github.com/DemocracyClub/uk-election-ids/releases/tag/0.10.0 on downstream apps I might as well do this. No impacts we need to account for here so we can just open the range