### PR TITLE
require uk-election-ids>=0.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
             "response_builder/v1/**/*",
         ]
     },
-    install_requires=["uk-election-ids>=0.8.0", "pydantic[email]>=1.10,<2"],
+    install_requires=["uk-election-ids>=0.10.0", "pydantic[email]>=1.10,<2"],
 )


### PR DESCRIPTION
Bump the min required version of uk-election-ids
Running with lower than this will cause `Allowed values for subtype are ('c', 'r')` when trying to construct a Ballot object with a new Senedd ID like `senedd.afan-ogwr-rhondda.2026-05-07`